### PR TITLE
Fixed arg for run_client_server in doc

### DIFF
--- a/docs/client_server_mode.md
+++ b/docs/client_server_mode.md
@@ -32,7 +32,7 @@ Where: _sc-server-run_ and _sc-client-run_ are docker names of SAI-Challenger se
 
 Alternatively, you can run the whole client-server environment on the same host with a single script:
 ```sh
-./run_client_server.sh start -a trident2 -t saivs
+./run_client_server.sh -a trident2 -t saivs start
 ./run_client_server.sh start
 ```
 


### PR DESCRIPTION
Changed argument order in doc for run_client_server.sh.

Error due 
./run_client_server.sh -a trident2 -t saivs start
```
ASIC type: 
docker: Error response from daemon: Conflict. The container name "/sc-client-run" is already in use by container "f8d2768ad14aaabd012550f8f5a3081670ac19682c285ac8eaf13fb967f7c1dc". You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.
ERROR: "docker run --name sc-client-run -v $(pwd):/sai-challenger --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun ${OPTS} -d sc-client" command filed with exit code 125.
```
