### PR TITLE
Added support in thrift client for 0:null check tests

### DIFF
--- a/common/sai_client/sai_thrift_client/sai_thrift_utils.py
+++ b/common/sai_client/sai_thrift_client/sai_thrift_utils.py
@@ -46,7 +46,7 @@ class ThriftConverter():
                 continue
             result_attrs.append(name)
             result_attrs.append(ThriftConverter.convert_value_from_thrift(value, ThriftConverter.get_attribute_type(name)))
-        #print(f"====TK====res={result_attrs}")
+
         return result_attrs
 
 
@@ -119,7 +119,9 @@ class ThriftConverter():
         elif attr_name == 'SAI_FDB_FLUSH_ATTR_BV_ID':
             return "oid"
         elif attr_name == 'SAI_PORT_ATTR_FABRIC_ISOLATE':
-            return "oid"
+            return "booldata"
+        elif attr_name == 'SAI_PORT_ATTR_MAX_FEC_SYMBOL_ERRORS_DETECTABLE':
+            return "u32"
         return SaiMetadata[attr_name]
 
     @staticmethod
@@ -215,7 +217,7 @@ class ThriftConverter():
         "16"       => 16
         "oid:0x10" => 16
         """
-        if oid == None:
+        if oid == None or oid == 'null' or oid == 'oid:0x0':
             return 0
         if isinstance(oid, str) and oid.startswith('oid:0x'):
             return int(oid[4:], 16)
@@ -264,8 +266,7 @@ class ThriftConverter():
         elif value_type in [ 'u8list', 'u16list', 'u32list',
                              's8list', 's16list', 's32list' ]:
             return ThriftConverter.from_sai_int_list(value_type, value)
-        elif value_type in [  'u32range' , 's32range', 'u16range' ]:
-            return ThriftConverter.from_sai_int_range(value_type, value)
+
         # TODO: Add more thrift->string convertes here
         raise NotImplementedError
 
@@ -274,6 +275,8 @@ class ThriftConverter():
         """
         sai_thrift_object_list_t(count=2, idlist=[1,2]) => "2:oid:0x1,oid:0x2"
         """
+        if object_list.count == 0:
+            return '0:null'
         result = f'{object_list.count}:'
         for ii in range(object_list.count):
             result += "oid:" + hex(object_list.idlist[ii])
@@ -292,21 +295,6 @@ class ThriftConverter():
             result += str(listvar[ii])
             result += ","
         return result[:-1]
-    
-    @staticmethod
-    def from_sai_int_range(value_type, object_list):
-        print(f"===TK777===value_type={value_type}, object_list={object_list}")
-        """
-        sai_thrift_{}_range_t(min=1, max=7) => {type}"1,7"
-        """
-        prefix = "uint" if value_type.startswith("u") else "int"
-        #listvar = getattr(object_list, prefix + value_type[1:])
-        #result = f'{object_list.count}:'
-        
-        #for ii in range(object_list.count):
-        #    result += str(listvar[ii])
-        #    result += ","
-        #return result[:-1]
 
 # AUXILARY
 

--- a/common/sai_client/sai_thrift_client/sai_thrift_utils.py
+++ b/common/sai_client/sai_thrift_client/sai_thrift_utils.py
@@ -46,7 +46,7 @@ class ThriftConverter():
                 continue
             result_attrs.append(name)
             result_attrs.append(ThriftConverter.convert_value_from_thrift(value, ThriftConverter.get_attribute_type(name)))
-
+        #print(f"====TK====res={result_attrs}")
         return result_attrs
 
 
@@ -264,7 +264,8 @@ class ThriftConverter():
         elif value_type in [ 'u8list', 'u16list', 'u32list',
                              's8list', 's16list', 's32list' ]:
             return ThriftConverter.from_sai_int_list(value_type, value)
-
+        elif value_type in [  'u32range' , 's32range', 'u16range' ]:
+            return ThriftConverter.from_sai_int_range(value_type, value)
         # TODO: Add more thrift->string convertes here
         raise NotImplementedError
 
@@ -291,6 +292,21 @@ class ThriftConverter():
             result += str(listvar[ii])
             result += ","
         return result[:-1]
+    
+    @staticmethod
+    def from_sai_int_range(value_type, object_list):
+        print(f"===TK777===value_type={value_type}, object_list={object_list}")
+        """
+        sai_thrift_{}_range_t(min=1, max=7) => {type}"1,7"
+        """
+        prefix = "uint" if value_type.startswith("u") else "int"
+        #listvar = getattr(object_list, prefix + value_type[1:])
+        #result = f'{object_list.count}:'
+        
+        #for ii in range(object_list.count):
+        #    result += str(listvar[ii])
+        #    result += ","
+        #return result[:-1]
 
 # AUXILARY
 


### PR DESCRIPTION
Fix for tests:
ut/test_port_ut.py::test_get_before_set_attr[SAI_PORT_ATTR_FABRIC_ISOLATE-bool] ut/test_port_ut.py::test_get_before_set_attr[SAI_PORT_ATTR_MAX_FEC_SYMBOL_ERRORS_DETECTABLE-sai_uint32_t]
ut/test_vlan_ut.py::test_get_before_set_attr[SAI_VLAN_ATTR_MEMBER_LIST-sai_object_list_t-0:null]
ut/test_vlan_ut.py::test_set_attr[SAI_VLAN_ATTR_TAM_OBJECT-0:null]
ut/test_vlan_ut.py::test_get_after_set_attr[SAI_VLAN_ATTR_MEMBER_LIST-sai_object_list_t-0:null]