### PR TITLE
Added try..exept for thrift function call

### DIFF
--- a/common/sai_client/sai_thrift_client/sai_thrift_client.py
+++ b/common/sai_client/sai_thrift_client/sai_thrift_client.py
@@ -185,9 +185,10 @@ class SaiThriftClient(SaiClient):
             # E.g., 1000x_sgmii_slave_autodetect
             if attr[0].isdigit():
                 attr = '_' + attr
-
-            thrift_attr_value = sai_thrift_function(self.thrift_client, **object_key, **{attr: value})
-
+            try:
+                thrift_attr_value = sai_thrift_function(self.thrift_client, **object_key, **{attr: value})
+            except:
+                thrift_attr_value = SaiStatus['FAILURE']
             if operation == 'set':
                 # No need to have a list here, since set always takes only one attribute at a time
                 status = ThriftConverter.convert_to_sai_status_str(thrift_attr_value)


### PR DESCRIPTION
Fix for tests:
ut/test_vlan_ut.py::test_set_attr_negative[SAI_VLAN_ATTR_VLAN_ID-101-!SAI_STATUS_SUCCESS]
ut/test_vlan_ut.py::test_vlan_mbr_set_negative[SAI_VLAN_MEMBER_ATTR_VLAN_ID]
ut/test_vlan_ut.py::test_vlan_mbr_set_negative[SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID]

For VLAN for set() operation we have to use vlan_oid from create() operation and every attr we can set() using only this oid, no vlan_id is used
because:
```
    /**
     * @brief Vlan Id
     *
     * @type sai_uint16_t
     * @flags MANDATORY_ON_CREATE | CREATE_ONLY | KEY
     * @isvlan true
     */
    SAI_VLAN_ATTR_VLAN_ID = SAI_VLAN_ATTR_START,
```
So, we have only vlan_oid for this in sai_thrift_set_vlan_attribute(client, vlan_oid, ...

But in test for set() operation we use vlan_id:
pl. see: https://github.com/opencomputeproject/SAI-Challenger/blob/main/tests/ut/test_vlan_ut.py#L172
```
@pytest.mark.parametrize(
    "attr,attr_value,expected_status",
    [
        ("SAI_VLAN_ATTR_VLAN_ID", "101", "!SAI_STATUS_SUCCESS"),
    ]
)
def test_set_attr_negative(npu, dataplane, sai_vlan_obj, attr, attr_value, expected_status):
    status = npu.set(sai_vlan_obj, [attr, attr_value], False)
    if expected_status[0] == "!":
        assert status != expected_status[1:]
    else:
        assert status == expected_status
```
So as we can't transmit this config over thift inteface, because we don't have parameter in sai_thrift_set_vlan_attribute()
now exception generated with FAILURE status

The same problem we have for vlan member
``` 
    /**
     * @brief VLAN ID
     *
     * @type sai_object_id_t
     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
     * @objects SAI_OBJECT_TYPE_VLAN
     */
    SAI_VLAN_MEMBER_ATTR_VLAN_ID = SAI_VLAN_MEMBER_ATTR_START,
    
    /**
     * @brief Bridge port ID.
     *
     * Valid only for .1Q bridge ports.
     *
     * @type sai_object_id_t
     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
     * @objects SAI_OBJECT_TYPE_BRIDGE_PORT
     */
    SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID,
```   
For sai_thrift_set_vlan_member_attribute() we have only vlan_member_oid parameter.
But in test we are trying to set using these attrs that  we can use only in create() operation:
pl. see: https://github.com/opencomputeproject/SAI-Challenger/blob/main/tests/ut/test_vlan_ut.py#L250
```
@pytest.mark.parametrize(
    "attr",
    [
        ("SAI_VLAN_MEMBER_ATTR_VLAN_ID"),
        ("SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID")
    ]
)
def test_vlan_mbr_set_negative(npu, dataplane, sai_vlan_member, attr):
    status = ""
    if attr == "SAI_VLAN_MEMBER_ATTR_VLAN_ID":
        status = npu.set(sai_vlan_member[0], [attr, npu.default_vlan_oid], False)
    elif attr == "SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID":
        status = npu.set(sai_vlan_member[0], [attr, npu.dot1q_bp_oids[0]], False)
    assert status != "SAI_STATUS_SUCCESS"
```
So as we can't transmit this config over thift inteface, because we don't have parameter in sai_thrift_set_vlan_attribute()
an exception generated with FAILURE status 