### PR TITLE
Allow uppercase for docker server image in run.sh script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -159,11 +159,12 @@ if [ "${COMMAND}" = "start" ]; then
             --device /dev/net/tun:/dev/net/tun \
             -d ${IMG_NAME}
     elif [ "${IMAGE_TYPE}" = "server" ]; then
-        docker run --name sc-server-${ASIC_TYPE}-${TARGET}-run \
+        IMG_NAME=$(echo "sc-server-${ASIC_TYPE}-${TARGET}" | tr '[:upper:]' '[:lower:]')
+        docker run --name ${IMG_NAME}-run \
             --cap-add=NET_ADMIN \
             ${OPTS} \
             --device /dev/net/tun:/dev/net/tun \
-            -d sc-server-${ASIC_TYPE}-${TARGET}
+            -d ${IMG_NAME}
     else
         docker run --name ${PREFIX}-client-run \
             -v $(pwd):/sai-challenger \


### PR DESCRIPTION
After building docker with parameters:
```
./build.sh -i server -a BCM81724 -t saivs
```
want to run docker with the same parameters and have an error:
```
./run.sh -i server -a BCM81724 -t saivs
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
ERROR: "docker run --name sc-server-${ASIC_TYPE}-${TARGET}-run --cap-add=NET_ADMIN ${OPTS} --device /dev/net/tun:/dev/net/tun -d sc-server-${ASIC_TYPE}-${TARGET}" command filed with exit code 125.
```
This fix allows to use lowercase or uppercase letters for docker image naming