### PR TITLE
Remove .build directory from previous unsuccessful build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,9 @@ if [[ "${IMAGE_TYPE}" != "standalone" && \
     exit 1
 fi
 
+# Clean the previous build
+rm -rf .build/
+
 if [[ "${IMAGE_TYPE}" != "client" ]]; then
 
     if [ -z "${ASIC_TYPE}" ]; then


### PR DESCRIPTION
Sometimes when the previous build failed:
```
./build.sh -i server -a BCM81724 -t saivs
...
09 | >>> COPY .build/npu          /sai-challenger/npu
 110 |     
 111 |     # Deploy a remote commands listener
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref moby::s3mhi1406eolp8yhfc1v13d92: "/.build/npu": not found
ERROR: "docker build -f dockerfiles/Dockerfile.server -t sc-server-base ." command filed with exit code 1.
```
Can't run build.sh the second time:
```
./build.sh -i server -a BCM81724 -t saivs
Unknown target "saivs"
```